### PR TITLE
Support audio pauses

### DIFF
--- a/espeakup.c
+++ b/espeakup.c
@@ -231,7 +231,8 @@ int main(int argc, char **argv)
 	pthread_join(softsynth_thread_id, NULL);
 	pthread_join(espeak_thread_id, NULL);
 
-	espeak_Terminate();
+	if (!paused_espeak)
+		espeak_Terminate();
 	close_softsynth();
 
 out:

--- a/espeakup.h
+++ b/espeakup.h
@@ -45,6 +45,7 @@ enum command_t {
 	CMD_SET_VOLUME,
 	CMD_SPEAK_TEXT,
 	CMD_FLUSH,
+	CMD_PAUSE,
 	CMD_UNKNOWN,
 };
 
@@ -86,6 +87,7 @@ extern void close_softsynth(void);
 extern void *softsynth_thread(void *arg);
 extern volatile int should_run;
 extern volatile int stop_requested;
+extern int paused_espeak;
 extern int self_pipe_fds[2];
 #define PIPE_READ_FD (self_pipe_fds[0])
 #define PIPE_WRITE_FD (self_pipe_fds[1])

--- a/softsynth.c
+++ b/softsynth.c
@@ -133,6 +133,9 @@ static int process_command(struct synth_t *s, char *buf, int start)
 		case 'v':
 			cmd = CMD_SET_VOLUME;
 			break;
+		case 'P':
+			cmd = CMD_PAUSE;
+			break;
 		default:
 			cmd = CMD_UNKNOWN;
 			break;


### PR DESCRIPTION
When the Linux console is e.g. switched to a graphical VT, the kernel
emits \x01P to notify that it is not able to read the screen any more,
and the software synthesis can thus release the audio card, for other
screen readers to take over.

This implements it by adding a paused_espeak variable that tracks
whether we have suspended espeak.  When more text comes, we can simply
reinitialize espeak.